### PR TITLE
🧹 add license to project

### DIFF
--- a/.copywrite.hcl
+++ b/.copywrite.hcl
@@ -1,0 +1,17 @@
+schema_version = 1
+
+project {
+  license          = "BUSL-1.1"
+  copyright_holder = "Mondoo, Inc."
+  copyright_year   = 2023
+
+  # (OPTIONAL) A list of globs that should not have copyright/license headers.
+  # Supports doublestar glob patterns for more flexibility in defining which
+  # files or folders should be ignored
+  header_ignore = [
+    "**/*.tf",
+    "**/testdata/**",
+    "**/*.pb.go",
+    "**/*_string.go",
+  ]
+}

--- a/.github/workflows/cla.yaml
+++ b/.github/workflows/cla.yaml
@@ -1,9 +1,9 @@
-name: "CLA Assistant"
+name: "CLA Assistant & License Check"
 on:
   issue_comment:
     types: [created]
   pull_request_target:
-    types: [opened,closed,synchronize]
+    types: [opened, closed, synchronize]
 
 jobs:
   CLAssistant:
@@ -14,13 +14,25 @@ jobs:
         uses: contributor-assistant/github-action@v2.2.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PERSONAL_ACCESS_TOKEN : ${{ secrets.CLA_ACCESS_TOKEN }}
+          PERSONAL_ACCESS_TOKEN: ${{ secrets.CLA_ACCESS_TOKEN }}
         with:
-          path-to-signatures: 'signatures/version1/cla.json'
-          path-to-document: 'https://github.com/mondoohq/.github/blob/master/CLA.md'
-          custom-pr-sign-comment: 'I have read the Mondoo CLA Document and I hereby sign the CLA'
-          custom-notsigned-prcomment: 'Thank you for your submission, we really appreciate it. Before we can accept your contribution, we ask that you sign the [Mondoo Contributor License Agreement](https://github.com/mondoohq/.github/blob/master/CLA.md). You can sign the CLA by adding a new comment to this pull request and pasting exactly the following text.'
+          path-to-signatures: "signatures/version1/cla.json"
+          path-to-document: "https://github.com/mondoohq/.github/blob/master/CLA.md"
+          custom-pr-sign-comment: "I have read the Mondoo CLA Document and I hereby sign the CLA"
+          custom-notsigned-prcomment: "Thank you for your submission, we really appreciate it. Before we can accept your contribution, we ask that you sign the [Mondoo Contributor License Agreement](https://github.com/mondoohq/.github/blob/master/CLA.md). You can sign the CLA by adding a new comment to this pull request and pasting exactly the following text."
           remote-repository-name: cla
           remote-organization-name: mondoohq
-          branch: 'main'
+          branch: "main"
           allowlist: mondoo-tools,github-actions[bot],dependabot[bot]
+
+  license-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Copywrite
+        uses: hashicorp/setup-copywrite@v1.1.2
+
+      - name: Check Header Compliance
+        run: copywrite headers --plan

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,41 @@
+License text copyright (c) 2020 MariaDB Corporation Ab, All Rights Reserved.
+“Business Source License” is a trademark of MariaDB Corporation Ab.
+
+Parameters
+
+Licensor:               Mondoo, Inc. (“Mondoo”)
+Licensed Work(s):       cnquery & cnspec arch package version 8.29.0 and
+                        later. The Licensed Work is (c) 2023 Mondoo, Inc.
+Additional Use Grant:   You may use, distribute or host the Licensed Work in
+                        your own or your direct customers’ production
+                        environment, provided that such use, distribution or
+                        hosting does not include offering the Licensed Work to
+                        third parties as part of or in connection with an
+                        offering that is competitive with any of Mondoo’s
+                        products.
+Change Date:            Four years from the date the Licensed Work is published
+Change License:         MPL 2.0
+
+For information about alternative licensing arrangements for the Licensed Work, please contact licensing@mondoo.com.
+
+Notice
+
+Business Source License 1.1
+
+Terms
+
+The Licensor hereby grants you the right to copy, modify, create derivative works, redistribute, and make non-production use of the Licensed Work. The Licensor may make an Additional Use Grant, above, permitting limited production use.
+
+Effective on the Change Date, or the fourth anniversary of the first publicly available distribution of a specific version of the Licensed Work under this License, whichever comes first, the Licensor hereby grants you rights under the terms of the Change License, and the rights granted in the paragraph above terminate.
+
+If your use of the Licensed Work does not comply with the requirements currently in effect as described in this License, you must purchase a commercial license from the Licensor, its affiliated entities, or authorized resellers, or you must refrain from using the Licensed Work.
+
+All copies of the original and modified Licensed Work, and derivative works of the Licensed Work, are subject to this License. This License applies separately for each version of the Licensed Work and the Change Date may vary for each version of the Licensed Work released by Licensor.
+
+You must conspicuously display this License on each original or modified copy of the Licensed Work. If you receive the Licensed Work in original or modified form from a third party, the terms and conditions set forth in this License apply to your use of that work.
+
+Any use of the Licensed Work in violation of this License will automatically terminate your rights under this License for the current and all other versions of the Licensed Work.
+
+This License does not grant you any right in any trademark or logo of Licensor or its affiliates (provided that you may use a trademark or logo of Licensor as expressly required by this License).
+
+TO THE EXTENT PERMITTED BY APPLICABLE LAW, THE LICENSED WORK IS PROVIDED ON AN “AS IS” BASIS. LICENSOR HEREBY DISCLAIMS ALL WARRANTIES AND CONDITIONS, EXPRESS OR IMPLIED, INCLUDING (WITHOUT LIMITATION) WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, AND TITLE.

--- a/Makefile
+++ b/Makefile
@@ -9,3 +9,11 @@ update-cnquery:
 update-cnspec:
 	go run ./generator/main.go cnspec ./cnspec
 
+# Copywrite Check Tool: https://github.com/hashicorp/copywrite
+license: license/headers/check
+
+license/headers/check:
+	copywrite headers --plan
+
+license/headers/apply:
+	copywrite headers

--- a/cnquery/.SRCINFO
+++ b/cnquery/.SRCINFO
@@ -4,7 +4,7 @@ pkgver = 8.28.4
 pkgrel = 1
 url = https://mondoo.com
 arch = x86_64
-license = MPL 2.0
+license = BUSL-1.1
 source = https://releases.mondoo.com/cnquery/8.28.4/cnquery_8.28.4_linux_amd64.tar.gz
 
 sha256sums = 

--- a/cnquery/PKGBUILD
+++ b/cnquery/PKGBUILD
@@ -8,7 +8,7 @@ pkgver="${orignalVersion/-/_}"
 pkgrel=1
 pkgdesc="Cloud-Native Query - Asset Inventory Framework"
 url="https://mondoo.com"
-license=('MPL 2.0')
+license=('BUSL-1.1')
 source=(
     "https://releases.mondoo.com/cnquery/${orignalVersion}/cnquery_${orignalVersion}_linux_amd64.tar.gz"
     )

--- a/cnspec/.SRCINFO
+++ b/cnspec/.SRCINFO
@@ -4,7 +4,7 @@ pkgver = 8.28.4
 pkgrel = 1
 url = https://mondoo.com
 arch = x86_64
-license = MPL 2.0
+license = BUSL-1.1
 source = https://releases.mondoo.com/cnspec/8.28.4/cnspec_8.28.4_linux_amd64.tar.gz
 
 sha256sums = 0958e21799835cae03fd372c70b03ea3ea3d42d33db616c25fbcf4cee1c718e5

--- a/cnspec/PKGBUILD
+++ b/cnspec/PKGBUILD
@@ -8,7 +8,7 @@ pkgver="${orignalVersion/-/_}"
 pkgrel=1
 pkgdesc="Cloud-Native Security and Policy Framework "
 url="https://mondoo.com"
-license=('MPL 2.0')
+license=('BUSL-1.1')
 source=(
     "https://releases.mondoo.com/cnspec/${orignalVersion}/cnspec_${orignalVersion}_linux_amd64.tar.gz"
     )

--- a/generator/main.go
+++ b/generator/main.go
@@ -1,3 +1,6 @@
+// Copyright (c) Mondoo, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
 package main
 
 import (
@@ -73,7 +76,7 @@ var products = map[string]Product{
 		Homepage:    "https://mondoo.com",
 		PkgName:     "cnquery",
 		Class:       "Cnquery",
-		License:     "MPL 2.0",
+		License:     "BUSL-1.1",
 	},
 	"cnspec": {
 		LatestUrl:   "https://releases.mondoo.com/cnspec/latest.json?ignoreCache=1",
@@ -81,7 +84,7 @@ var products = map[string]Product{
 		Homepage:    "https://mondoo.com",
 		PkgName:     "cnspec",
 		Class:       "Cnspec",
-		License:     "MPL 2.0",
+		License:     "BUSL-1.1",
 		Depends: []string{
 			"cnquery",
 		},

--- a/mondoo/LICENSE.html
+++ b/mondoo/LICENSE.html
@@ -1,4 +1,9 @@
 <!DOCTYPE html>
+<!--
+ Copyright (c) Mondoo, Inc.
+ SPDX-License-Identifier: BUSL-1.1
+-->
+
 
 <html class="no-js" lang="en-US">
 

--- a/mondoo/mondoo.sh
+++ b/mondoo/mondoo.sh
@@ -1,3 +1,6 @@
 #!/bin/sh
+# Copyright (c) Mondoo, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
 /opt/mondoo/bin/mondoo --config /etc/opt/mondoo/mondoo.yml "$@"
 


### PR DESCRIPTION
This updates the cnquery and cnspec package information license to BUSL-1.1 and add BUSL 1.1 to this repository itself.